### PR TITLE
Added the possibility to configure the webview from the android side.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.RequiresApi;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -62,6 +63,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -151,7 +153,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     RNCWebView webView = createRNCWebViewInstance(reactContext);
     setupWebChromeClient(reactContext, webView);
     reactContext.addLifecycleEventListener(webView);
-    mWebViewConfig.configWebView(webView);
+
     WebSettings settings = webView.getSettings();
     settings.setBuiltInZoomControls(true);
     settings.setDisplayZoomControls(false);
@@ -212,6 +214,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       }
     });
 
+    mWebViewConfig.configWebView(webView);
     return webView;
   }
 
@@ -443,7 +446,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
-    view.setWebViewClient(new RNCWebViewClient());
+    if(view instanceof RNCWebView){
+      if(((RNCWebView) view).getRNCWebViewClient() == null) view.setWebViewClient(new RNCWebViewClient());
+    }
+    else{
+      view.setWebViewClient(new RNCWebViewClient());
+    }
   }
 
   @Override
@@ -588,7 +596,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
-  protected static class RNCWebViewClient extends WebViewClient {
+  public static class RNCWebViewClient extends WebViewClient {
 
     protected boolean mLastLoadFailed = false;
     protected @Nullable

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewPackage.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewPackage.java
@@ -10,6 +10,18 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNCWebViewPackage implements ReactPackage {
+
+  private WebViewConfig globalNativeConfiguration;
+
+  public RNCWebViewPackage(){
+    super();
+  }
+
+  public RNCWebViewPackage(WebViewConfig globalConfigurator){
+    super();
+    this.globalNativeConfiguration = globalConfigurator;
+  }
+
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Collections.singletonList(new RNCWebViewModule(reactContext));
@@ -22,6 +34,7 @@ public class RNCWebViewPackage implements ReactPackage {
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Collections.singletonList(new RNCWebViewManager());
+    RNCWebViewManager manager = globalNativeConfiguration != null ? new RNCWebViewManager(globalNativeConfiguration) : new RNCWebViewManager();
+    return Collections.singletonList(manager);
   }
 }


### PR DESCRIPTION
I had a rather curious use case. I needed to override a bunch or URLs being loaded through a static website inside the device, mounted in a react-native-webview. In order to do that, I needed to set a bunch of listeners in the webview. Since the tutorial in the react-native-webview (https://facebook.github.io/react-native/docs/custom-webview-android) was outdated, I started reading the repo and found an interface that can be used to configure the webview component, which would allow to solve complex use cases like mine without having to create a custom react webview and therefore keeping the JS code untouched. 

Changes:
1.- Added the 'WebViewConfig globalNativeConfigurator' member to the Package class (RNCWebViewPackage)

2.- Added a constructor 'public RNCWebViewPackage(WebViewConfig)' to the Package class so the user can send the configuration instance.

3.- Added logic to the 'createViewManagers(ReactApplicationContext)' method so the logic can be passed to the module, if available.

4.- Moved the 'mWebViewConfig.configWebView(WebView)' invocation in the 'createViewInstance' method to the last line to ensure it does override the default.

5.- Added logic to the 'addEventEmitters(ThemedReactContext, WebView)' method to avoid having the configuration reset after the createViewInstance call if the WebViewClient is already set and is an RNCWebViewClient instance.

6.-  Exposed the RNCWebViewClient class to ensure the configuration sent by the user can provide a fully compatible WebViewClient.